### PR TITLE
Misc. Patches

### DIFF
--- a/.claude/hooks/lib/__tests__/affinity-injection.test.ts
+++ b/.claude/hooks/lib/__tests__/affinity-injection.test.ts
@@ -195,7 +195,7 @@ describe('Affinity Injection System', () => {
       expect(affinities).toEqual([]);
     });
 
-    it('should not inject affinity skill with autoInject: false', () => {
+    it('should inject affinity skill even with autoInject: false (affinity overrides)', () => {
       const skillRules: Record<string, SkillRule> = {
         'parent-skill': {
           type: 'domain',
@@ -203,14 +203,15 @@ describe('Affinity Injection System', () => {
         },
         'manual-skill': {
           type: 'domain',
-          autoInject: false, // Manual load required
+          autoInject: false,
         },
       };
 
       const affinities = findAffinityInjections(['parent-skill'], [], skillRules);
 
-      // Should not inject manual-skill (autoInject: false)
-      expect(affinities).toEqual([]);
+      // autoInject: false no longer blocks affinity injection —
+      // it only gates keyword fallback, not AI-scored or affinity paths
+      expect(affinities).toEqual(['manual-skill']);
     });
 
     it('should handle multiple skills being injected with overlapping affinities', () => {

--- a/.claude/hooks/lib/__tests__/skill-filtering.test.ts
+++ b/.claude/hooks/lib/__tests__/skill-filtering.test.ts
@@ -173,10 +173,10 @@ describe('Skill Filtering', () => {
   });
 
   describe('filterAndPromoteSkills (Integration)', () => {
-    it('should filter + promote when 1 critical already loaded', () => {
+    it('should not count acknowledged guardrails toward domain slot reduction', () => {
       const requiredSkills = ['python-best-practices', 'api-security'];
       const suggestedSkills = ['git-workflow', 'skill-developer'];
-      const acknowledged = ['api-security'];
+      const acknowledged = ['api-security']; // guardrail — doesn't reduce domain slots
       const skillRules: Record<string, SkillRule> = {
         'python-best-practices': { type: 'domain' },
         'api-security': { type: 'guardrail' },
@@ -191,17 +191,17 @@ describe('Skill Filtering', () => {
         skillRules
       );
 
-      // Target = 2 - 1 (acknowledged critical) = 1 domain slot
-      // python-best-practices fills 1 domain slot
-      expect(result.toInject).toEqual(['python-best-practices']);
-      expect(result.promoted).toEqual([]);
-      expect(result.remainingSuggested).toEqual(['git-workflow', 'skill-developer']);
+      // Target = 2 - 0 (guardrail doesn't count) = 2 domain slots
+      // python-best-practices (critical) + git-workflow (promoted)
+      expect(result.toInject).toEqual(['python-best-practices', 'git-workflow']);
+      expect(result.promoted).toEqual(['git-workflow']);
+      expect(result.remainingSuggested).toEqual(['skill-developer']);
     });
 
-    it('should promote when all critical skills already loaded', () => {
+    it('should reduce slots only for acknowledged domain skills', () => {
       const requiredSkills = ['python-best-practices', 'api-security'];
       const suggestedSkills = ['git-workflow', 'skill-developer'];
-      const acknowledged = ['python-best-practices', 'api-security'];
+      const acknowledged = ['python-best-practices', 'api-security']; // 1 domain + 1 guardrail
       const skillRules: Record<string, SkillRule> = {
         'python-best-practices': { type: 'domain' },
         'api-security': { type: 'guardrail' },
@@ -216,11 +216,11 @@ describe('Skill Filtering', () => {
         skillRules
       );
 
-      // Target = 2 - 2 (acknowledged) = 0 domain slots
-      // No skills to inject
-      expect(result.toInject).toEqual([]);
-      expect(result.promoted).toEqual([]);
-      expect(result.remainingSuggested).toEqual(['git-workflow', 'skill-developer']);
+      // Target = 2 - 1 (only domain python-best-practices counts) = 1 domain slot
+      // git-workflow promoted to fill the 1 slot
+      expect(result.toInject).toEqual(['git-workflow']);
+      expect(result.promoted).toEqual(['git-workflow']);
+      expect(result.remainingSuggested).toEqual(['skill-developer']);
     });
 
     it('should promote 2 suggested domain skills and always include guardrails', () => {

--- a/.claude/hooks/lib/__tests__/skill-filtering.test.ts
+++ b/.claude/hooks/lib/__tests__/skill-filtering.test.ts
@@ -18,59 +18,60 @@ describe('Skill Filtering', () => {
     it('should filter out already acknowledged skills', () => {
       const skills = ['python-best-practices', 'git-workflow', 'api-security'];
       const acknowledged = ['python-best-practices', 'git-workflow'];
-      const skillRules: Record<string, SkillRule> = {
-        'python-best-practices': { type: 'domain' },
-        'git-workflow': { type: 'domain' },
-        'api-security': { type: 'guardrail' },
-      };
 
-      const unacknowledged = filterUnacknowledgedSkills(skills, acknowledged, skillRules);
+      const unacknowledged = filterUnacknowledgedSkills(skills, acknowledged);
 
       expect(unacknowledged).toEqual(['api-security']);
     });
 
-    it('should filter out skills with autoInject: false', () => {
+    it('should return all skills when none acknowledged', () => {
       const skills = ['python-best-practices', 'skill-developer', 'api-security'];
       const acknowledged: string[] = [];
-      const skillRules: Record<string, SkillRule> = {
-        'python-best-practices': { type: 'domain' },
-        'skill-developer': {
-          type: 'domain',
-          autoInject: false,
-        },
-        'api-security': { type: 'guardrail' },
-      };
 
-      const unacknowledged = filterUnacknowledgedSkills(skills, acknowledged, skillRules);
+      const unacknowledged = filterUnacknowledgedSkills(skills, acknowledged);
 
-      expect(unacknowledged).toEqual(['python-best-practices', 'api-security']);
+      expect(unacknowledged).toEqual(['python-best-practices', 'skill-developer', 'api-security']);
     });
   });
 
   describe('applyInjectionLimits', () => {
-    it('should inject up to 2 critical skills when acknowledgedCriticalCount = 0', () => {
+    // All domain skills for basic limit tests
+    const domainRules: Record<string, SkillRule> = {
+      'skill-a': { type: 'domain' },
+      'skill-b': { type: 'domain' },
+      'skill-c': { type: 'domain' },
+      'skill-d': { type: 'domain' },
+      'skill-e': { type: 'domain' },
+    };
+
+    it('should inject up to 2 domain skills when acknowledgedCriticalCount = 0', () => {
       const critical = ['skill-a', 'skill-b', 'skill-c'];
       const recommended: string[] = [];
-      const acknowledgedCriticalCount = 0; // No critical skills loaded yet
+      const acknowledgedCriticalCount = 0;
 
-      const { toInject } = applyInjectionLimits(critical, recommended, acknowledgedCriticalCount);
+      const { toInject } = applyInjectionLimits(
+        critical,
+        recommended,
+        acknowledgedCriticalCount,
+        domainRules
+      );
 
       expect(toInject).toHaveLength(2);
       expect(toInject).toEqual(['skill-a', 'skill-b']);
     });
 
     it('should promote recommended skills to fill empty slots', () => {
-      const critical = ['skill-a']; // 1 critical
+      const critical = ['skill-a'];
       const recommended = ['skill-b', 'skill-c', 'skill-d'];
       const acknowledgedCriticalCount = 0;
 
       const { toInject, promoted } = applyInjectionLimits(
         critical,
         recommended,
-        acknowledgedCriticalCount
+        acknowledgedCriticalCount,
+        domainRules
       );
 
-      // Should inject 1 critical + 1 promoted = 2 total
       expect(toInject).toHaveLength(2);
       expect(toInject).toEqual(['skill-a', 'skill-b']);
       expect(promoted).toEqual(['skill-b']);
@@ -84,43 +85,42 @@ describe('Skill Filtering', () => {
       const { toInject, promoted } = applyInjectionLimits(
         critical,
         recommended,
-        acknowledgedCriticalCount
+        acknowledgedCriticalCount,
+        domainRules
       );
 
-      // Should promote 2 recommended to reach target
       expect(toInject).toHaveLength(2);
       expect(toInject).toEqual(['skill-a', 'skill-b']);
       expect(promoted).toEqual(['skill-a', 'skill-b']);
     });
 
     it('should reduce target when critical skills already acknowledged', () => {
-      const critical = ['skill-a']; // 1 unacknowledged critical
+      const critical = ['skill-a'];
       const recommended = ['skill-b', 'skill-c'];
-      const acknowledgedCriticalCount = 1; // 1 critical already loaded
+      const acknowledgedCriticalCount = 1;
 
-      // Target = 2 - 1 = 1 slot available
       const { toInject, promoted } = applyInjectionLimits(
         critical,
         recommended,
-        acknowledgedCriticalCount
+        acknowledgedCriticalCount,
+        domainRules
       );
 
-      // Should inject only 1 skill (target = 1)
       expect(toInject).toHaveLength(1);
       expect(toInject).toEqual(['skill-a']);
       expect(promoted).toEqual([]);
     });
 
-    it('should inject 0 skills when 2 critical skills already acknowledged', () => {
-      const critical: string[] = []; // No unacknowledged critical
+    it('should inject 0 domain skills when 2 already acknowledged', () => {
+      const critical: string[] = [];
       const recommended = ['skill-a', 'skill-b'];
-      const acknowledgedCriticalCount = 2; // 2 critical already loaded (target met)
+      const acknowledgedCriticalCount = 2;
 
-      // Target = 2 - 2 = 0 slots available
       const { toInject, promoted } = applyInjectionLimits(
         critical,
         recommended,
-        acknowledgedCriticalCount
+        acknowledgedCriticalCount,
+        domainRules
       );
 
       expect(toInject).toEqual([]);
@@ -135,18 +135,46 @@ describe('Skill Filtering', () => {
       const { toInject, promoted, remainingSuggested } = applyInjectionLimits(
         critical,
         recommended,
-        acknowledgedCriticalCount
+        acknowledgedCriticalCount,
+        domainRules
       );
 
       expect(toInject).toEqual(['skill-a', 'skill-b']);
       expect(promoted).toEqual(['skill-b']);
       expect(remainingSuggested).toEqual(['skill-c', 'skill-d', 'skill-e']);
     });
+
+    it('should always include guardrail skills exempt from 2-skill cap', () => {
+      const mixedRules: Record<string, SkillRule> = {
+        'guardrail-a': { type: 'guardrail' },
+        'domain-a': { type: 'domain' },
+        'domain-b': { type: 'domain' },
+        'domain-c': { type: 'domain' },
+      };
+
+      const critical = ['guardrail-a', 'domain-a', 'domain-b', 'domain-c'];
+      const recommended: string[] = [];
+      const acknowledgedCriticalCount = 0;
+
+      const { toInject } = applyInjectionLimits(
+        critical,
+        recommended,
+        acknowledgedCriticalCount,
+        mixedRules
+      );
+
+      // Guardrail always included + 2 domain skills (cap)
+      expect(toInject).toContain('guardrail-a');
+      expect(toInject).toContain('domain-a');
+      expect(toInject).toContain('domain-b');
+      expect(toInject).not.toContain('domain-c');
+      expect(toInject).toHaveLength(3);
+    });
   });
 
   describe('filterAndPromoteSkills (Integration)', () => {
     it('should filter + promote when 1 critical already loaded', () => {
-      const requiredSkills = ['python-best-practices', 'api-security']; // api-security already loaded
+      const requiredSkills = ['python-best-practices', 'api-security'];
       const suggestedSkills = ['git-workflow', 'skill-developer'];
       const acknowledged = ['api-security'];
       const skillRules: Record<string, SkillRule> = {
@@ -163,15 +191,15 @@ describe('Skill Filtering', () => {
         skillRules
       );
 
-      // Target = 2 - 1 (acknowledged critical) = 1 slot
-      // Should inject python-best-practices only (fills the 1 slot)
+      // Target = 2 - 1 (acknowledged critical) = 1 domain slot
+      // python-best-practices fills 1 domain slot
       expect(result.toInject).toEqual(['python-best-practices']);
       expect(result.promoted).toEqual([]);
       expect(result.remainingSuggested).toEqual(['git-workflow', 'skill-developer']);
     });
 
     it('should promote when all critical skills already loaded', () => {
-      const requiredSkills = ['python-best-practices', 'api-security']; // Both already loaded
+      const requiredSkills = ['python-best-practices', 'api-security'];
       const suggestedSkills = ['git-workflow', 'skill-developer'];
       const acknowledged = ['python-best-practices', 'api-security'];
       const skillRules: Record<string, SkillRule> = {
@@ -188,14 +216,14 @@ describe('Skill Filtering', () => {
         skillRules
       );
 
-      // Target = 2 - 2 (acknowledged) = 0 slots
-      // Should inject nothing (target met)
+      // Target = 2 - 2 (acknowledged) = 0 domain slots
+      // No skills to inject
       expect(result.toInject).toEqual([]);
       expect(result.promoted).toEqual([]);
       expect(result.remainingSuggested).toEqual(['git-workflow', 'skill-developer']);
     });
 
-    it('should promote 2 suggested when no critical skills', () => {
+    it('should promote 2 suggested domain skills and always include guardrails', () => {
       const requiredSkills: string[] = [];
       const suggestedSkills = ['python-best-practices', 'api-security', 'git-workflow'];
       const acknowledged: string[] = [];
@@ -212,13 +240,16 @@ describe('Skill Filtering', () => {
         skillRules
       );
 
-      // Target = 2, no critical → promote 2 suggested
-      expect(result.toInject).toEqual(['python-best-practices', 'api-security']);
-      expect(result.promoted).toEqual(['python-best-practices', 'api-security']);
-      expect(result.remainingSuggested).toEqual(['git-workflow']);
+      // Guardrail (api-security) always included + 2 domain promoted
+      expect(result.toInject).toContain('api-security');
+      expect(result.toInject).toContain('python-best-practices');
+      expect(result.toInject).toContain('git-workflow');
+      expect(result.toInject).toHaveLength(3);
+      expect(result.promoted).toEqual(['python-best-practices', 'git-workflow']);
+      expect(result.remainingSuggested).toEqual([]);
     });
 
-    it('should handle skills with autoInject: false correctly', () => {
+    it('should include all skills when AI scores them (autoInject: false no longer filters)', () => {
       const requiredSkills = ['python-best-practices'];
       const suggestedSkills = ['skill-developer', 'git-workflow'];
       const acknowledged: string[] = [];
@@ -226,7 +257,7 @@ describe('Skill Filtering', () => {
         'python-best-practices': { type: 'domain' },
         'skill-developer': {
           type: 'domain',
-          autoInject: false, // Manual load only
+          autoInject: false,
         },
         'git-workflow': { type: 'domain' },
       };
@@ -238,10 +269,11 @@ describe('Skill Filtering', () => {
         skillRules
       );
 
-      // Should skip skill-developer (autoInject: false) and promote git-workflow
-      expect(result.toInject).toEqual(['python-best-practices', 'git-workflow']);
-      expect(result.promoted).toEqual(['git-workflow']);
-      expect(result.remainingSuggested).toEqual([]);
+      // autoInject: false no longer blocks AI-scored skills from injection
+      // python-best-practices (critical) + skill-developer (promoted) fill 2 slots
+      expect(result.toInject).toEqual(['python-best-practices', 'skill-developer']);
+      expect(result.promoted).toEqual(['skill-developer']);
+      expect(result.remainingSuggested).toEqual(['git-workflow']);
     });
   });
 });

--- a/.claude/hooks/lib/cache-manager.ts
+++ b/.claude/hooks/lib/cache-manager.ts
@@ -16,7 +16,7 @@ import {
   statSync,
 } from 'fs';
 import { join } from 'path';
-import { CACHE_TTL_MS, CACHE_CLEANUP_AGE_MS } from './constants.js';
+import { CACHE_TTL_MS, CACHE_CLEANUP_AGE_MS, DEBUG_ENABLED } from './constants.js';
 import type { CacheEntry } from './types.js';
 
 // Use project root for cache directory, not hooks cwd
@@ -104,14 +104,14 @@ function cleanupOldCacheEntries(): void {
         }
       } catch (err) {
         // Log in debug mode for troubleshooting
-        if (process.env.CLAUDE_SKILL_DEBUG === 'true') {
+        if (DEBUG_ENABLED) {
           console.warn(`Cache cleanup: failed to process ${file}:`, err);
         }
       }
     });
   } catch (err) {
     // Log directory-level errors in debug mode
-    if (process.env.CLAUDE_SKILL_DEBUG === 'true') {
+    if (DEBUG_ENABLED) {
       console.warn('Cache cleanup failed:', err);
     }
   }

--- a/.claude/hooks/lib/constants.ts
+++ b/.claude/hooks/lib/constants.ts
@@ -42,6 +42,10 @@ export const CACHE_CLEANUP_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
 // Skills without explicit injectionOrder use this value (mid-range 0-100)
 export const DEFAULT_INJECTION_ORDER = 50;
 
+// Debug mode toggle
+// Controlled by CLAUDE_SKILLS_DEBUG=1 environment variable
+export const DEBUG_ENABLED = process.env.CLAUDE_SKILLS_DEBUG === '1';
+
 // Banner formatting
 // Character width for visual consistency in terminal output
 export const BANNER_WIDTH = 45;

--- a/.claude/hooks/lib/debug-logger.ts
+++ b/.claude/hooks/lib/debug-logger.ts
@@ -7,8 +7,9 @@
 
 import { appendFileSync, existsSync, statSync, renameSync } from 'fs';
 import { join } from 'path';
+import { DEBUG_ENABLED } from './constants.js';
 
-const DEBUG_SKILLS = process.env.CLAUDE_SKILLS_DEBUG === '1';
+const DEBUG_SKILLS = DEBUG_ENABLED;
 const MAX_LOG_SIZE = 10 * 1024 * 1024; // 10MB
 
 /**

--- a/.claude/hooks/lib/intent-analyzer.ts
+++ b/.claude/hooks/lib/intent-analyzer.ts
@@ -10,7 +10,7 @@
  */
 
 import { createHash } from 'crypto';
-import { SHORT_PROMPT_WORD_THRESHOLD } from './constants.js';
+import { SHORT_PROMPT_WORD_THRESHOLD, DEBUG_ENABLED } from './constants.js';
 import { readCache, writeCache } from './cache-manager.js';
 import { callAnthropicAPI } from './anthropic-client.js';
 import { matchSkillsByKeywords } from './keyword-matcher.js';
@@ -64,7 +64,7 @@ export async function analyzeIntent(
     const analysis = await callAnthropicAPI(prompt, availableSkills);
 
     // Debug logging
-    if (process.env.CLAUDE_SKILL_DEBUG === 'true') {
+    if (DEBUG_ENABLED) {
       formatDebugOutput(analysis);
     }
 
@@ -75,8 +75,18 @@ export async function analyzeIntent(
     const result = buildAnalysisResult(
       categorized,
       analysis,
-      process.env.CLAUDE_SKILL_DEBUG === 'true'
+      DEBUG_ENABLED
     );
+
+    // Guarantee guardrail skills are included even on long prompts where AI
+    // might under-score them. Keyword matcher only returns guardrail skills
+    // (autoInject !== false), so this union is safe.
+    const keywordHits = matchSkillsByKeywords(prompt, availableSkills);
+    for (const skill of keywordHits.required) {
+      if (!result.required.includes(skill) && !result.suggested.includes(skill)) {
+        result.required.push(skill);
+      }
+    }
 
     writeCache(cacheKey, { required: result.required, suggested: result.suggested });
     return result;

--- a/.claude/hooks/lib/keyword-matcher.ts
+++ b/.claude/hooks/lib/keyword-matcher.ts
@@ -38,6 +38,8 @@ export function matchSkillsByKeywords(
   const detected: string[] = [];
 
   for (const [name, config] of Object.entries(skills)) {
+    // Keyword fallback only returns guardrail skills; domain skills require AI analysis
+    if (config.autoInject === false) continue;
     const keywords = config.promptTriggers?.keywords || [];
     if (keywords.some((kw: string) => promptLower.includes(kw.toLowerCase()))) {
       detected.push(name);

--- a/.claude/hooks/lib/output-formatter.ts
+++ b/.claude/hooks/lib/output-formatter.ts
@@ -149,23 +149,6 @@ export function formatRecommendedSection(
 }
 
 /**
- * Format manual load section for skills with autoInject: false
- *
- * Shows skills that were matched but require manual loading via Skill tool.
- *
- * @param manualSkills - Skills that need manual loading
- * @returns Formatted section string
- */
-export function formatManualLoadSection(manualSkills: string[]): string {
-  if (manualSkills.length === 0) return '';
-
-  let output = '\n📚 MANUAL LOAD REQUIRED (autoInject: false):\n';
-  manualSkills.forEach((name) => (output += `  → ${name}\n`));
-  output += '\nACTION: Use Skill tool for these skills\n';
-  return output;
-}
-
-/**
  * Format closing banner for skill activation check
  *
  * @returns Formatted closing banner

--- a/.claude/hooks/lib/skill-filtration.ts
+++ b/.claude/hooks/lib/skill-filtration.ts
@@ -186,8 +186,11 @@ export function filterAndPromoteSkills(
   const unacknowledgedCritical = filterUnacknowledgedSkills(requiredSkills, acknowledged);
   const unacknowledgedRecommended = filterUnacknowledgedSkills(suggestedSkills, acknowledged);
 
-  // Calculate how many critical skills are already loaded
-  const acknowledgedCriticalCount = requiredSkills.filter((s) => acknowledged.includes(s)).length;
+  // Calculate how many critical domain skills are already loaded (guardrails
+  // are exempt from the cap, so they shouldn't reduce domain slots)
+  const acknowledgedCriticalCount = requiredSkills.filter(
+    (s) => acknowledged.includes(s) && skillRules[s]?.type !== 'guardrail'
+  ).length;
 
   // Apply promotion to reach 2-skill target (guardrails exempt from cap)
   return applyInjectionLimits(

--- a/.claude/hooks/lib/skill-filtration.ts
+++ b/.claude/hooks/lib/skill-filtration.ts
@@ -17,60 +17,68 @@ export interface FiltrationResult {
 }
 
 /**
- * Filter out already acknowledged skills and those with autoInject: false
+ * Filter out already acknowledged skills
  *
  * @param skills - Skills to filter
  * @param acknowledged - Previously acknowledged skills
- * @param skillRules - Skill configuration
  * @returns Filtered list of unacknowledged skills
  */
 export function filterUnacknowledgedSkills(
   skills: string[],
-  acknowledged: string[],
-  skillRules: Record<string, SkillRule>
+  acknowledged: string[]
 ): string[] {
-  return skills.filter(
-    (skill) => !acknowledged.includes(skill) && skillRules[skill]?.autoInject !== false
-  );
+  return skills.filter((skill) => !acknowledged.includes(skill));
 }
 
 /**
  * Apply skill injection limits with promotion logic
  *
- * Promotes suggested skills to fill the 2-skill target. Target calculation
- * accounts for critical skills already loaded in the session.
+ * Guardrail skills are always included (exempt from cap). The 2-skill cap
+ * applies only to domain skills. Promotes suggested domain skills to fill
+ * the target. Target calculation accounts for domain skills already loaded.
  *
  * @param criticalSkills - Unacknowledged required skills (confidence > 0.65)
  * @param recommendedSkills - Unacknowledged suggested skills (confidence 0.50-0.65)
  * @param acknowledgedCriticalCount - Count of critical skills already loaded
+ * @param skillRules - Skill configuration (used to identify guardrails)
  * @returns Object with skills to inject, promoted skills, and remaining suggested
  */
 export function applyInjectionLimits(
   criticalSkills: string[],
   recommendedSkills: string[],
-  acknowledgedCriticalCount: number
+  acknowledgedCriticalCount: number,
+  skillRules: Record<string, SkillRule>
 ): FiltrationResult {
-  const TARGET_SLOTS = 2; // Standard 2-skill injection limit
+  const TARGET_SLOTS = 2; // Standard 2-skill injection limit (domain skills only)
 
-  // Calculate promotion target: 2 total - already loaded critical skills
+  // Separate guardrail skills from domain skills — guardrails are exempt from cap
+  const criticalGuardrails = criticalSkills.filter((s) => skillRules[s]?.type === 'guardrail');
+  const criticalDomain = criticalSkills.filter((s) => skillRules[s]?.type !== 'guardrail');
+  const recommendedDomain = recommendedSkills.filter((s) => skillRules[s]?.type !== 'guardrail');
+  const recommendedGuardrails = recommendedSkills.filter((s) => skillRules[s]?.type === 'guardrail');
+
+  // Calculate promotion target for domain skills: 2 total - already loaded domain critical
   const promotionTarget = Math.max(0, TARGET_SLOTS - acknowledgedCriticalCount);
 
-  // Start with critical skills (up to promotion target)
-  const toInject = [...criticalSkills.slice(0, promotionTarget)];
+  // Start with critical domain skills (up to promotion target)
+  const domainToInject = [...criticalDomain.slice(0, promotionTarget)];
 
-  // Calculate how many more skills we need to reach target
-  const needed = Math.max(0, promotionTarget - toInject.length);
+  // Calculate how many more domain skills we need to reach target
+  const needed = Math.max(0, promotionTarget - domainToInject.length);
 
-  // Promote recommended skills to fill empty slots
+  // Promote recommended domain skills to fill empty slots
   const promotedRecommended: string[] = [];
-  if (needed > 0 && recommendedSkills.length > 0) {
-    const promoted = recommendedSkills.slice(0, needed);
+  if (needed > 0 && recommendedDomain.length > 0) {
+    const promoted = recommendedDomain.slice(0, needed);
     promotedRecommended.push(...promoted);
-    toInject.push(...promoted);
+    domainToInject.push(...promoted);
   }
 
-  // Remaining recommended skills (not promoted)
-  const remainingSuggested = recommendedSkills.filter((s) => !promotedRecommended.includes(s));
+  // Always include all guardrails (exempt from cap)
+  const toInject = [...criticalGuardrails, ...recommendedGuardrails, ...domainToInject];
+
+  // Remaining recommended skills (not promoted, excluding guardrails already included)
+  const remainingSuggested = recommendedDomain.filter((s) => !promotedRecommended.includes(s));
 
   return {
     toInject,
@@ -128,15 +136,8 @@ export function findAffinityInjections(
     // Enforce max 2 items at runtime (matches schema constraint)
     const affinities = (config?.affinity || []).slice(0, 2);
     for (const affinity of affinities) {
-      // Only inject if:
-      // 1. Not already acknowledged (loaded in session)
-      // 2. Not already in toInject list
-      // 3. autoInject is not false
-      if (
-        !acknowledged.includes(affinity) &&
-        !toInject.includes(affinity) &&
-        skillRules[affinity]?.autoInject !== false
-      ) {
+      // Only inject if not already acknowledged or in toInject list
+      if (!acknowledged.includes(affinity) && !toInject.includes(affinity)) {
         affinitySet.add(affinity);
       }
     }
@@ -147,15 +148,8 @@ export function findAffinityInjections(
     for (const [otherSkill, otherConfig] of Object.entries(skillRules)) {
       const otherAffinities = otherConfig.affinity || [];
       if (otherAffinities.includes(skill)) {
-        // Only inject if:
-        // 1. Not already acknowledged
-        // 2. Not already in toInject
-        // 3. autoInject is not false
-        if (
-          !acknowledged.includes(otherSkill) &&
-          !toInject.includes(otherSkill) &&
-          otherConfig.autoInject !== false
-        ) {
+        // Only inject if not already acknowledged or in toInject
+        if (!acknowledged.includes(otherSkill) && !toInject.includes(otherSkill)) {
           affinitySet.add(otherSkill);
         }
       }
@@ -189,24 +183,17 @@ export function filterAndPromoteSkills(
   skillRules: Record<string, SkillRule>
 ): FiltrationResult {
   // Filter out acknowledged skills
-  const unacknowledgedCritical = filterUnacknowledgedSkills(
-    requiredSkills,
-    acknowledged,
-    skillRules
-  );
-  const unacknowledgedRecommended = filterUnacknowledgedSkills(
-    suggestedSkills,
-    acknowledged,
-    skillRules
-  );
+  const unacknowledgedCritical = filterUnacknowledgedSkills(requiredSkills, acknowledged);
+  const unacknowledgedRecommended = filterUnacknowledgedSkills(suggestedSkills, acknowledged);
 
   // Calculate how many critical skills are already loaded
   const acknowledgedCriticalCount = requiredSkills.filter((s) => acknowledged.includes(s)).length;
 
-  // Apply promotion to reach 2-skill target
+  // Apply promotion to reach 2-skill target (guardrails exempt from cap)
   return applyInjectionLimits(
     unacknowledgedCritical,
     unacknowledgedRecommended,
-    acknowledgedCriticalCount
+    acknowledgedCriticalCount,
+    skillRules
   );
 }

--- a/.claude/hooks/lib/skill-state-manager.ts
+++ b/.claude/hooks/lib/skill-state-manager.ts
@@ -6,7 +6,7 @@
  * per-conversation using conversation_id or session_id.
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import type { SessionState } from './types.js';
 
@@ -80,8 +80,15 @@ export function writeSessionState(
     // This prevents corruption if multiple hooks run concurrently
     writeFileSync(tempFile, JSON.stringify(stateData, null, 2));
 
-    // renameSync is atomic on POSIX systems - overwrites existing file atomically
-    renameSync(tempFile, stateFile);
+    // renameSync is atomic on POSIX systems - overwrites existing file atomically.
+    // On Windows, renameSync fails if the target exists, so fall back to
+    // unlinkSync + renameSync.
+    try {
+      renameSync(tempFile, stateFile);
+    } catch {
+      unlinkSync(stateFile);
+      renameSync(tempFile, stateFile);
+    }
   } catch (err) {
     // Don't fail the hook if state writing fails
     console.error('Warning: Failed to write session state:', err);

--- a/.claude/hooks/package-lock.json
+++ b/.claude/hooks/package-lock.json
@@ -1123,6 +1123,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.2.tgz",
             "integrity": "sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~7.16.0"
             }
@@ -1162,6 +1163,7 @@
             "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.55.0",
                 "@typescript-eslint/types": "8.55.0",
@@ -1477,6 +1479,7 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1732,6 +1735,7 @@
             "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -2446,6 +2450,7 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -2743,6 +2748,7 @@
             "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
             "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "~0.27.0",
                 "get-tsconfig": "^4.7.5"
@@ -2775,6 +2781,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -2805,6 +2812,7 @@
             "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",

--- a/.claude/hooks/package.json
+++ b/.claude/hooks/package.json
@@ -12,8 +12,7 @@
         "format:check": "prettier --check '**/*.ts'",
         "test": "vitest run",
         "test:watch": "vitest watch",
-        "test:coverage": "vitest run --coverage",
-        "test:integration": "tsx skill-activation-prompt.ts < test-input.json"
+        "test:coverage": "vitest run --coverage"
     },
     "dependencies": {
         "@anthropic-ai/sdk": "^0.74.0",

--- a/.claude/hooks/skill-activation-prompt.sh
+++ b/.claude/hooks/skill-activation-prompt.sh
@@ -11,4 +11,4 @@ if [ -f .env ]; then
     set +a
 fi
 
-cat | npx tsx skill-activation-prompt.ts
+cat | npx tsx skill-activation-prompt.ts || true

--- a/.claude/hooks/skill-activation-prompt.ts
+++ b/.claude/hooks/skill-activation-prompt.ts
@@ -19,7 +19,6 @@ import {
   formatJustInjectedSection,
   formatAlreadyLoadedSection,
   formatRecommendedSection,
-  formatManualLoadSection,
   formatClosingBanner,
 } from './lib/output-formatter.js';
 import type { SkillRulesConfig } from './lib/types.js';
@@ -155,13 +154,6 @@ async function main(): Promise<void> {
 
       // Show remaining recommended skills
       output += formatRecommendedSection(filtration.remainingSuggested, analysis.scores);
-
-      // Show manual-load required skills (autoInject: false)
-      const manualSkills = [...requiredDomainSkills, ...suggestedDomainSkills].filter((skill) => {
-        const skillRule = rules.skills[skill];
-        return !existingAcknowledged.includes(skill) && skillRule?.autoInject === false;
-      });
-      output += formatManualLoadSection(manualSkills);
 
       output += formatClosingBanner();
       console.log(output);

--- a/.claude/skills/skill-rules.json
+++ b/.claude/skills/skill-rules.json
@@ -3,7 +3,7 @@
   "skills": {
     "skill-developer": {
       "type": "domain",
-      "autoInject": true,
+      "autoInject": false,
       "requiredSkills": [],
       "description": "Skill for creating and managing Claude Code skills. Covers skill structure, YAML frontmatter, trigger patterns, hook mechanisms (UserPromptSubmit), session tracking, 500-line rule, progressive disclosure, and relationship to CLAUDE.md. Use when creating new skills, modifying skill-rules.json, understanding triggers, debugging activation, or understanding the skills system architecture.",
       "promptTriggers": {
@@ -27,7 +27,7 @@
     },
     "python-best-practices": {
       "type": "domain",
-      "autoInject": true,
+      "autoInject": false,
       "requiredSkills": [],
       "description": "Python development best practices including PEP 8 style guidelines, type hints, docstring conventions (NumPy format), and common patterns. Use when writing or modifying Python code.",
       "promptTriggers": {
@@ -44,7 +44,7 @@
     },
     "git-workflow": {
       "type": "domain",
-      "autoInject": true,
+      "autoInject": false,
       "requiredSkills": [],
       "description": "Git workflow best practices including commit messages (Conventional Commits), branching strategies, pull requests, and collaboration patterns. Use when working with Git version control.",
       "promptTriggers": {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Skills Supercharged
 
-[![Tests](https://img.shields.io/badge/tests-120%20passing-brightgreen)](https://github.com/jefflester/claude-skills-supercharged)
+[![Tests](https://img.shields.io/badge/tests-passing-brightgreen)](https://github.com/jefflester/claude-skills-supercharged)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.3-blue)](https://www.typescriptlang.org/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Claude
@@ -24,7 +24,7 @@ context—every time.
 
 | Metric | Value |
 |--------|-------|
-| ✅ Test Coverage | **120/120 tests passing** |
+| ✅ Test Coverage | **All tests passing** |
 | ⚡ Response Time | **<10ms** (cached) / ~200ms (first call) |
 | 💰 Monthly Cost | **$1-2** @ 100 prompts/day |
 | 🎯 Accuracy | **95%+** skill detection rate |
@@ -84,7 +84,7 @@ automatically. 🎉
   content in resources
 - 🛡️ **Guardrail Skills** — Enforce critical best practices (e.g., API
   security, input validation)
-- ✅ **Comprehensive Testing** — 120 tests with full coverage of the injection
+- ✅ **Comprehensive Testing** — Full coverage of the injection
   pipeline
 
 ## 🚀 Quick Start


### PR DESCRIPTION
Fix autoInject design flaw and 6 smaller issues from Copilot PR review.

**Key change:** `autoInject: false` was blocking domain skills from injection even when AI scored them as relevant. Moved the guard to the keyword-matcher fallback path only, so AI-scored and affinity-based injection work correctly. Guardrail skills are now exempt from the 2-skill cap and guaranteed via keyword union on long prompts.

Also: unified debug env var, added Windows renameSync fallback, shell wrapper `|| true`, removed dead code, updated tests (121 passing).

Resolves #53.